### PR TITLE
ESC9 template bug fix: 🐛 removed email from inclusion in SAN

### DIFF
--- a/files/ESC9.json
+++ b/files/ESC9.json
@@ -4,24 +4,24 @@
     "objectClass":  "pKICertificateTemplate",
     "flags":  131642,
     "revision":  100,
-    "msPKI-Cert-Template-OID":  "1.3.6.1.4.1.311.21.8.15259740.2305984.9191596.2842136.3011317.52.13375922.9841897",
+    "msPKI-Cert-Template-OID":  "1.3.6.1.4.1.311.21.8.12926314.13933278.9259679.1328214.12908673.21.15721773.8953759",
     "msPKI-Certificate-Application-Policy":  [
                                                  "1.3.6.1.4.1.311.10.3.4",
                                                  "1.3.6.1.5.5.7.3.4",
                                                  "1.3.6.1.5.5.7.3.2"
                                              ],
-    "msPKI-Certificate-Name-Flag":  -1509949440,
+    "msPKI-Certificate-Name-Flag":  33554432,
     "msPKI-Enrollment-Flag":  524329,
     "msPKI-Minimal-Key-Size":  2048,
     "msPKI-Private-Key-Flag":  16842768,
     "msPKI-RA-Signature":  0,
-    "msPKI-Template-Minor-Revision":  3,
+    "msPKI-Template-Minor-Revision":  4,
     "msPKI-Template-Schema-Version":  2,
     "pKICriticalExtensions":  [
-                                  "2.5.29.15"
+                                  "2.5.29.15",
+                                  "2.5.29.7"
                               ],
     "pKIDefaultCSPs":  [
-                           "2,Microsoft Base Cryptographic Provider v1.0",
                            "1,Microsoft Enhanced Cryptographic Provider v1.0"
                        ],
     "pKIDefaultKeySpec":  1,


### PR DESCRIPTION
reconfigured the ESC9 template to prevent the template from requiring an email address to be added to the subjectAltName. This was preventing the ESC9 template from being requested as the current iteration of this role does not add email addresses to users by default.

Apologies for the oversight in the previous PR - I've confirmed that ESC9 can be performed on this iteration of the template without the need for other admin actions to enable it