### PR TITLE
feat: added support for template name customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,30 @@ Available variables are listed below, along with default values (see `defaults/m
     ludus_adcs_esc13_user: esc13user
     ludus_adcs_esc13_password: ESC13password
     ludus_adcs_esc13_group: esc13group
-    ludus_adcs_esc13_template: ESC13
 
     ludus_adcs_esc16_user: esc16user
     ludus_adcs_esc16_password: ESC16password
+
+    # Template display name customization
+    ludus_adcs_esc1_display_name: "ESC1"
+    ludus_adcs_esc2_display_name: "ESC2"
+    ludus_adcs_esc3_display_name: "ESC3"
+    ludus_adcs_esc3_cra_display_name: "ESC3_CRA"
+    ludus_adcs_esc4_display_name: "ESC4"
+    ludus_adcs_esc7_display_name: "ESC7_CertMgr"
+    ludus_adcs_esc9_display_name: "ESC9"
+    ludus_adcs_esc13_display_name: "ESC13"
+
+    ludus_adcs_template_display_names:
+        ESC1: "{{ ludus_adcs_esc1_display_name }}"
+        ESC2: "{{ ludus_adcs_esc2_display_name }}"
+        ESC3: "{{ ludus_adcs_esc3_display_name }}"
+        ESC3_CRA: "{{ ludus_adcs_esc3_cra_display_name }}"
+        ESC4: "{{ ludus_adcs_esc4_display_name }}"
+        ESC7_CERTMGR: "{{ ludus_adcs_esc7_display_name }}"
+        ESC9: "{{ ludus_adcs_esc9_display_name }}"
+        ESC13: "{{ ludus_adcs_esc13_display_name }}"
+
 
 ## Dependencies
 
@@ -101,6 +121,16 @@ None.
     ludus_adcs_esc13: true
     ludus_adcs_esc15: true
     ludus_adcs_esc16: true
+    # Rename templates (optional)
+    ludus_adcs_template_display_names:
+        ESC1: "WorkstationAuth"
+        ESC2: "DocEncryption"
+        ESC3: "EmployeeCert"
+        ESC3_CRA: "EnrollmentAgent"
+        ESC4: "LegacyApp"
+        ESC7_CERTMGR: "Certmgr"
+        ESC9: "ServerAuth"
+        ESC13: "Smartcard" 
 ```
 
 ## Example Ludus Range Config
@@ -123,6 +153,16 @@ ludus:
       - badsectorlabs.ludus_adcs
     role_vars:
       ludus_adcs_esc6: false # By default ESC1,2,3,4,5,6,7,8,9,11,13,15, and 16 are enabled
+      # Rename templates (optional)
+      ludus_adcs_template_display_names:
+        ESC1: "WorkstationAuth"
+        ESC2: "DocEncryption"
+        ESC3: "EmployeeCert"
+        ESC3_CRA: "EnrollmentAgent"
+        ESC4: "LegacyApp"
+        ESC7_CERTMGR: "Certmgr"
+        ESC9: "ServerAuth"
+        ESC13: "Smartcard"
 ```
 
 ## License
@@ -140,3 +180,5 @@ The inlcuded [PSPKI](https://github.com/PKISolutions/PSPKI/) project is licensed
 This role was created in 2024 by [Bad Sector Labs](https://badsectorlabs.com/), for [Ludus](https://ludus.cloud/).
 
 Support for ESC5, ESC7, ESC9, ESC11, and ESC15 was added in November 2024, and ESC16 in May 2025 by [Brady McLaughlin](https://github.com/bradyjmcl).
+
+Support for template name customization in October 2025 by [mojeda101](https://github.com/mojeda101).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,7 +38,26 @@ ludus_adcs_esc9_password: ESC9password
 ludus_adcs_esc13_user: esc13user
 ludus_adcs_esc13_password: ESC13password
 ludus_adcs_esc13_group: esc13group
-ludus_adcs_esc13_template: ESC13
 
 ludus_adcs_esc16_user: esc16user
 ludus_adcs_esc16_password: ESC16password
+
+# Template display name customization
+ludus_adcs_esc1_display_name: "ESC1"
+ludus_adcs_esc2_display_name: "ESC2"
+ludus_adcs_esc3_display_name: "ESC3"
+ludus_adcs_esc3_cra_display_name: "ESC3_CRA"
+ludus_adcs_esc4_display_name: "ESC4"
+ludus_adcs_esc7_display_name: "ESC7_CertMgr"
+ludus_adcs_esc9_display_name: "ESC9"
+ludus_adcs_esc13_display_name: "ESC13"
+
+ludus_adcs_template_display_names:
+  ESC1: "{{ ludus_adcs_esc1_display_name }}"
+  ESC2: "{{ ludus_adcs_esc2_display_name }}"
+  ESC3: "{{ ludus_adcs_esc3_display_name }}"
+  ESC3_CRA: "{{ ludus_adcs_esc3_cra_display_name }}"
+  ESC4: "{{ ludus_adcs_esc4_display_name }}"
+  ESC7_CERTMGR: "{{ ludus_adcs_esc7_display_name }}"
+  ESC9: "{{ ludus_adcs_esc9_display_name }}"
+  ESC13: "{{ ludus_adcs_esc13_display_name }}"

--- a/tasks/esc11.yml
+++ b/tasks/esc11.yml
@@ -49,6 +49,6 @@
     ansible_become_password: "{{ ludus_adcs_domain_password }}"
   register: esc11_start_output
 
-- name: Output ESC7 script result
+- name: Output ESC11 script result
   ansible.builtin.debug:
     var: esc11_start_output

--- a/tasks/esc13.yml
+++ b/tasks/esc13.yml
@@ -36,7 +36,7 @@
 
 - name: Run ESC13 script
   ansible.windows.win_shell: |
-    C:\ludus\adcs\esc13.ps1 -esc13group '{{ ludus_adcs_esc13_group }}' -esc13templateName '{{ ludus_adcs_esc13_template }}' -esc13user '{{ ludus_adcs_esc13_user }}'
+    C:\ludus\adcs\esc13.ps1 -esc13group '{{ ludus_adcs_esc13_group }}' -esc13templateName '{{ ludus_adcs_esc13_display_name }}' -esc13user '{{ ludus_adcs_esc13_user }}'
   become: true
   become_method: runas
   vars:

--- a/tasks/esc4.yml
+++ b/tasks/esc4.yml
@@ -71,7 +71,7 @@
       }
     parameters:
       for: "Domain Users"
-      to: "CN=ESC4,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC={{ ludus_domain_netbios_name }},DC={{ ludus_domain_fqdn_tail.split('.') | join(',DC=') }}"
+      to: "CN={{ ludus_adcs_esc4_display_name }},CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC={{ ludus_domain_netbios_name }},DC={{ ludus_domain_fqdn_tail.split('.') | join(',DC=') }}"
       right: "GenericAll"
       inheritance: "None"
   vars:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -117,13 +117,28 @@
 
 - name: Install templates
   ansible.windows.win_shell: |
-    if (-not(Get-ADCSTemplate -DisplayName "{{ adcs_template_name }}")) { New-ADCSTemplate -DisplayName "{{ adcs_template_name }}" -JSON (Get-Content c:\ludus\adcs\{{ adcs_template_name }}.json -Raw) -Identity "{{ domain_name }}\Domain Users" -Publish }
+    $sourceFile = "{{ adcs_template_name }}"
+    $displayName = "{{ adcs_display_name }}"
+
+    Write-Host "Processing: SourceFile='$sourceFile.json' DisplayName='$displayName'"
+
+    if (-not(Get-ADCSTemplate -DisplayName "$displayName")) {
+      Write-Host "Creating template '$displayName' from $sourceFile.json"
+      New-ADCSTemplate -DisplayName "$displayName" `
+        -JSON (Get-Content "c:\ludus\adcs\$sourceFile.json" -Raw) `
+        -Identity "{{ domain_name }}\Domain Users" `
+        -Publish
+      Write-Host "Successfully created template '$displayName'"
+    } else {
+      Write-Host "Template '$displayName' already exists, skipping"
+    }
   vars:
     ansible_become: true
     ansible_become_method: runas
     domain_name: "{{ ludus_adcs_domain }}"
     ansible_become_user: "{{ ludus_adcs_domain_username }}"
     ansible_become_password: "{{ ludus_adcs_domain_password }}"
+    adcs_display_name: "{{ ludus_adcs_template_display_names[adcs_template_name] | default(adcs_template_name) }}"
   loop: "{{ escs_to_enable | upper }}"
   loop_control:
     loop_var: adcs_template_name
@@ -174,3 +189,4 @@
 
 - name: Refresh
   ansible.windows.win_command: gpupdate /force
+


### PR DESCRIPTION
Name customization of imported certificate templates.

For ESC13 I changed `ludus_adcs_esc13_template` to `ludus_adcs_esc13_display_name` because it made it overall easier to use.

In the task for ESC7 was a typo in the name so I fixed that too.

I hope that's okay.

The reason behind this modifcation is that when you build like a CTF range with this role you can change the names of the template however you want.