### PR TITLE
Internationalized some PS scripts and removed deprecation warnings

### DIFF
--- a/files/esc13_acls.ps1
+++ b/files/esc13_acls.ps1
@@ -4,7 +4,7 @@ param(
 )
 
 # Get DistinguishedNames
-$entAdminsDN = (Get-ADGroup -Identity 'Enterprise Admins').DistinguishedName
+$entAdminsDN = (Get-ADGroup -Identity "$((Get-ADDomain).DomainSID)-519").DistinguishedName
 $esc13groupDN = (Get-ADGroup -Identity $esc13group).DistinguishedName
 
 #Add GenericAll rights over Enterprise Admins to the esc13group

--- a/files/esc15.ps1
+++ b/files/esc15.ps1
@@ -3,6 +3,6 @@ Import-Module ADCSTemplate
 
 # Define the template and group name
 $displayName = "Web Server"
-$groupName = "Domain Users"
+$groupName = $groupName = (Get-ADGroup -Identity "$((Get-ADDomain).DomainSID)-513").Name
 
 Set-ADCSTemplateACL -DisplayName $displayName -Type Allow -Identity $groupName -Enroll

--- a/files/esc16.ps1
+++ b/files/esc16.ps1
@@ -4,7 +4,7 @@ param(
 )
 
 # Get DistinguishedNames
-$domainUsersDN = (Get-ADGroup -Identity 'Domain Users').DistinguishedName
+$domainUsersDN = (Get-ADGroup -Identity "$((Get-ADDomain).DomainSID)-513").DistinguishedName
 $esc16userDN = (Get-ADUser -Identity $esc16user).DistinguishedName
 
 #Add GenericAll rights over the esc16user to the Domain Users group

--- a/files/esc9.ps1
+++ b/files/esc9.ps1
@@ -4,7 +4,7 @@ param(
 )
 
 # Get DistinguishedNames
-$domainUsersDN = (Get-ADGroup -Identity 'Domain Users').DistinguishedName
+$domainUsersDN = (Get-ADGroup -Identity "$((Get-ADDomain).DomainSID)-513").DistinguishedName
 $esc9userDN = (Get-ADUser -Identity $esc9user).DistinguishedName
 
 #Add GenericAll rights over the esc9user to the Domain Users group

--- a/tasks/esc13.yml
+++ b/tasks/esc13.yml
@@ -4,7 +4,7 @@
     msg: "DC: {{ ludus_adcs_dc }} | CA: {{ ludus_adcs_ca_host }}"
 
 - name: Create an ESC13 domain user
-  community.windows.win_domain_user:
+  microsoft.ad.user:
     name: "{{ ludus_adcs_esc13_user }}"
     password: "{{ ludus_adcs_esc13_password }}"
     upn: "{{ ludus_adcs_esc13_user }}"
@@ -16,7 +16,7 @@
     domain_server: "{{ ludus_adcs_dc }}"
 
 - name: Create an ESC13 domain group
-  community.windows.win_domain_group:
+  microsoft.ad.group:
     name: "{{ ludus_adcs_esc13_group }}"
     scope: universal
     state: present

--- a/tasks/esc16.yml
+++ b/tasks/esc16.yml
@@ -4,7 +4,7 @@
     msg: "DC: {{ ludus_adcs_dc }} | CA: {{ ludus_adcs_ca_host }}"
 
 - name: Create an ESC16 domain user
-  community.windows.win_domain_user:
+  microsoft.ad.user:
     name: "{{ ludus_adcs_esc16_user }}"
     password: "{{ ludus_adcs_esc16_password }}"
     upn: "{{ ludus_adcs_esc16_user }}"
@@ -22,7 +22,8 @@
 
 - name: Run ESC16 script
   ansible.windows.win_shell: |
-    C:\ludus\adcs\esc16.ps1 -esc16user '{{ ludus_adcs_esc16_user }}' | Select-String -Pattern 'Domain Users'
+    $domainUsersName = (Get-ADGroup -Identity "$((Get-ADDomain).DomainSID)-513").Name
+    C:\ludus\adcs\esc16.ps1 -esc16user '{{ ludus_adcs_esc16_user }}' | Select-String -Pattern $domainUsersName
   become: true
   become_method: runas
   vars:

--- a/tasks/esc5.yml
+++ b/tasks/esc5.yml
@@ -4,7 +4,7 @@
     msg: "DC: {{ ludus_adcs_dc }} | CA: {{ ludus_adcs_ca_host }}"
 
 - name: Create an ESC5 domain user
-  community.windows.win_domain_user:
+  microsoft.ad.user:
     name: "{{ ludus_adcs_esc5_user }}"
     password: "{{ ludus_adcs_esc5_password }}"
     upn: "{{ ludus_adcs_esc5_user }}"
@@ -17,14 +17,14 @@
 
 - name: Check if user is already in the Administrators group
   ansible.windows.win_shell: |
-    (net localgroup Administrators | Select-String -Pattern '{{ ludus_adcs_esc5_user }}') -ne $null
+    if ((Get-WmiObject -Class Win32_ComputerSystem).DomainRole -ge 4) { (net group "$((Get-ADGroup -Identity "$((Get-ADDomain).DomainSID)-512").Name)" /domain | Select-String -Pattern '{{ ludus_adcs_esc5_user }}') -ne $null } else { (net localgroup S-1-5-32-544 | Select-String -Pattern '{{ ludus_adcs_esc5_user }}') -ne $null }
   register: user_is_admin
   args:
     executable: powershell
 
 - name: Add ESC5 user to local administrators group
   ansible.windows.win_shell: |
-    net localgroup administrators /add '{{ ludus_adcs_esc5_user }}'
+    if ((Get-WmiObject -Class Win32_ComputerSystem).DomainRole -ge 4) { net group "$((Get-ADGroup -Identity "$((Get-ADDomain).DomainSID)-512").Name)" '{{ ludus_adcs_esc5_user }}' /add /domain } else { net localgroup S-1-5-32-544 /add '{{ ludus_adcs_esc5_user }}' }
   become: true
   become_method: runas
   vars:

--- a/tasks/esc7.yml
+++ b/tasks/esc7.yml
@@ -4,7 +4,7 @@
     msg: "DC: {{ ludus_adcs_dc }} | CA: {{ ludus_adcs_ca_host }}"
 
 - name: Create an ESC7 CA Manager domain user
-  community.windows.win_domain_user:
+  microsoft.ad.user:
     name: "{{ ludus_adcs_esc7_ca_manager_user }}"
     password: "{{ ludus_adcs_esc7_ca_manager_password }}"
     upn: "{{ ludus_adcs_esc7_ca_manager_user }}"
@@ -16,7 +16,7 @@
     domain_server: "{{ ludus_adcs_dc }}"
 
 - name: Create an ESC7 Certificates Manager domain user
-  community.windows.win_domain_user:
+  microsoft.ad.user:
     name: "{{ ludus_adcs_esc7_cert_manager_user }}"
     password: "{{ ludus_adcs_esc7_cert_manager_password }}"
     upn: "{{ ludus_adcs_esc7_cert_manager_user }}"

--- a/tasks/esc9.yml
+++ b/tasks/esc9.yml
@@ -4,7 +4,7 @@
     msg: "DC: {{ ludus_adcs_dc }} | CA: {{ ludus_adcs_ca_host }}"
 
 - name: Create an ESC9 domain user
-  community.windows.win_domain_user:
+  microsoft.ad.user:
     name: "{{ ludus_adcs_esc9_user }}"
     password: "{{ ludus_adcs_esc9_password }}"
     upn: "{{ ludus_adcs_esc9_user }}"
@@ -22,7 +22,8 @@
 
 - name: Run ESC9 script
   ansible.windows.win_shell: |
-    C:\ludus\adcs\esc9.ps1 -esc9user '{{ ludus_adcs_esc9_user }}' | Select-String -Pattern 'Domain Users'
+    $domainUsersName = (Get-ADGroup -Identity "$((Get-ADDomain).DomainSID)-513").Name
+    C:\ludus\adcs\esc9.ps1 -esc9user '{{ ludus_adcs_esc9_user }}' | Select-String -Pattern $domainUsersName
   become: true
   become_method: runas
   vars:


### PR DESCRIPTION
Hello,

I tried to deploy this range using French Windows templates (using https://github.com/Croko-fr/ludus-templates) and faced errors due to the fact that some PS scripts were not internationalized, meaning there were commands like:

`(Get-ADGroup -Identity 'Enterprise Admins').DistinguishedName`

which I replaced by:

`(Get-ADGroup -Identity "$((Get-ADDomain).DomainSID)-519").DistinguishedName`

I also faced an error during the deployment of ESC5, due to the fact that I deployed the role on a DC (I know, it's bad!) and the script did not account for the fact that there are no local groups on a DC. I fixed that by first determining if the script was launched on a DC or a member server, and added the esc5 user to the correct group.

I also faced an error linked to the "Issuance Policy OID" part of the ESC13 script. Now, I must admit that I do not fully understand this part 😅 further than the code used "old ways" of doing things (`DirectoryEntry`) which can, under some circumstances, generate errors. I got help from Claude to upgrade this part of the code to a more "modern way" of doing things (`Set-ADObject`). Anyway, it works: no more errors, and the issuance OID policy is correctly linked.

Finally, I faced deprecation warnings in Ansible Yaml files which were using `community.windows.win_domain_user` and `community.windows.win_domain_group` to create users and groups. Nothing blocking as such, but while I was at it, I replaced them by their newer counterparts `microsoft.ad.user` and `microsoft.ad.group` to suppress these warnings.

Hope it helps!