### PR TITLE
fix: correctly check if CA was installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,7 +47,7 @@
         if ($_.Exception.ErrorId -eq 380) {
           # A certification authority with the same name was found in the Active Directory.
           # CA is already installed.
-          Write-Output $_.Exception.ErrorString
+          Write-Output $_.Exception.Message
         } else {
           $Ansible.Failed = $true
           throw $_
@@ -71,8 +71,14 @@
       try {
         Install-AdcsWebEnrollment -Force
         $Ansible.Changed = $true
+      } catch [Microsoft.CertificateServices.Deployment.Common.WEP.WebEnrollmentSetupException] {
+        # Web Enrollment is already installed
+        Write-Output $_.Exception.Message
+        $Ansible.Changed = $false
       } catch {
         $Ansible.Changed = $false
+        $Ansible.Failed = $true
+        throw $_
       }
   when: ludus_adcs_esc8
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,8 +42,20 @@
       try {
         Install-AdcsCertificationAuthority -Credential $Cred -CAType EnterpriseRootCA -CryptoProviderName "RSA#Microsoft Software Key Storage Provider" -KeyLength 2048 -HashAlgorithmName SHA256 -ValidityPeriod Years -ValidityPeriodUnits 5 -CACommonName $ca_common_name -Force
         $Ansible.Changed = $true
+      } catch [Microsoft.CertificateServices.Deployment.Common.CA.CertificationAuthoritySetupException] {
+        $Ansible.Changed = $false
+        if ($_.Exception.ErrorId -eq 380) {
+          # A certification authority with the same name was found in the Active Directory.
+          # CA is already installed.
+          Write-Output $_.Exception.ErrorString
+        } else {
+          $Ansible.Failed = $true
+          throw $_
+        }
       } catch {
         $Ansible.Changed = $false
+        $Ansible.Failed = $true
+        throw $_
       }
     error_action: stop
     parameters:


### PR DESCRIPTION
The try catch block simply swallows everything even if an actual error occured. This adds a specific catch block for the `CertificationAuthoritySetupException` and checks if the error id is 380.