### PR TITLE
fix: do not rely on ErrorID in catch block of installation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,14 +44,7 @@
         $Ansible.Changed = $true
       } catch [Microsoft.CertificateServices.Deployment.Common.CA.CertificationAuthoritySetupException] {
         $Ansible.Changed = $false
-        if ($_.Exception.ErrorId -eq 380) {
-          # A certification authority with the same name was found in the Active Directory.
-          # CA is already installed.
-          Write-Output $_.Exception.Message
-        } else {
-          $Ansible.Failed = $true
-          throw $_
-        }
+        Write-Output $_.Exception.Message
       } catch {
         $Ansible.Changed = $false
         $Ansible.Failed = $true


### PR DESCRIPTION
Turns out that checking for ErrorId 380 does not yield consistent behavior..